### PR TITLE
アイテムの位置を奥側に統一しておいた

### DIFF
--- a/GameTemplate/Game/LevelObjectBase.h
+++ b/GameTemplate/Game/LevelObjectBase.h
@@ -38,11 +38,23 @@ public:		//オーバーライドしてほしいメンバ関数
 	virtual void SwitchReverse(const bool frontOrBack = 0) {};
 
 protected:	//ここのメンバ関数を主に使う
+
 	/// <summary>
 	/// 近くのウェイポイントを探して、イイ感じに回転する関数
 	/// </summary>
-	void CheckWayPoint();
+	/// <param name="checkRotaton">回転チェックを行うか？</param>
+	/// <param name="checkPosition">座標チェックを行うか？</param>
+	void CheckWayPoint(const bool checkRotaton = true, const bool checkPosition = true);
+
+	/// <summary>
+	/// 現在の座標に合わせた回転にする
+	/// </summary>
 	void CheckRotation();
+
+	/// <summary>
+	/// ウェイポイントにそろえた座標にする
+	/// </summary>
+	void CheckPosition();
 
 public:		//ここのメンバ関数を主に使う
 
@@ -221,6 +233,15 @@ public:		//ここのメンバ関数を主に使う
 	/// </summary>
 	/// <param name="reversibleObject">反転オブジェクトか？</param>
 	void CheckFrontOrBackSide(const bool reversibleObject = true);
+	
+	/// <summary>
+	/// ウェイポイントからの奥行の距離を設定
+	/// </summary>
+	/// <param name="zPosLen">奥行の距離</param>
+	void SetZPosLen(const float zPosLen)
+	{
+		m_zPosLen = zPosLen;
+	}
 
 private:	//privateなメンバ関数
 
@@ -244,8 +265,7 @@ private:	//データメンバ
 	int m_rpIndex = 0;
 	int m_frontOrBackSide = CLevelObjectManager::enNone;	//自身が表側にあるか裏側にあるか
 	bool m_lock = false;					//ロック中か？、Tips表示や全反転をロックする
-
-
+	float m_zPosLen = 0.0f;					//ウェイポイントからの奥行の距離
 	////////////////////////////////////////////////////////////
 	// 透明オブジェクト用の変数と関数
 	////////////////////////////////////////////////////////////
@@ -259,6 +279,10 @@ public: //Set関数
 		m_flagIsHit = b;
 	}
 
+	/// <summary>
+	/// 重なっているかの判定の処理を行うか確認するフラグの値を取得
+	/// </summary>
+	/// <returns>m_flagIsHitの値</returns>
 	const bool GetFlagIsHit()const
 	{
 		return m_flagIsHit;
@@ -341,14 +365,8 @@ public: //透明スイッチに使用する関数
 		return m_flagHeld;
 	}
 
-	/// <summary>
-	/// 重なっているかの判定の処理を行うか確認するフラグの値を取得
-	/// </summary>
-	/// <returns>m_flagIsHitの値</returns>
-	bool GetFlagIsHit()
-	{
-		return m_flagIsHit;
-	}
+
+
 
 	//void SetFlagHeldPlayer(bool b)
 	//{

--- a/GameTemplate/Game/LevelObjectManager.h
+++ b/GameTemplate/Game/LevelObjectManager.h
@@ -241,6 +241,24 @@ public:		//ここのメンバ関数を主に使う
 		return m_levelObjects;
 	}
 
+	/// <summary>
+	/// ステージのメビウスの輪の参照を得る
+	/// </summary>
+	/// <returns>メビウスの輪の参照</returns>
+	Mobius* GetMobius()const
+	{
+		return m_mobius;
+	}
+
+	/// <summary>
+	/// ステージのメビウスの輪の参照を設定する
+	/// </summary>
+	/// <param name="mobius">メビウスの輪の参照</param>
+	void SetMobius(Mobius* mobius)
+	{
+		m_mobius = mobius;
+	}
+
 public:	//列挙体
 	/// <summary>
 	/// 表側か裏側か
@@ -263,6 +281,7 @@ private:	//データメンバ
 	int m_reversibleObjectNum[enFrontOrBackSideNum] = { 0,0 };
 	//反転オブジェクトの、表側と裏側のそれぞれの最大数
 	int m_reversibleObjectMaxNum[enFrontOrBackSideNum] = { 0,0 };
+	Mobius* m_mobius = nullptr;				//ステージのメビウスの輪のポインタ
 };
 
 

--- a/GameTemplate/Game/Mobius.cpp
+++ b/GameTemplate/Game/Mobius.cpp
@@ -1,5 +1,7 @@
 #include "stdafx.h"
 #include "Mobius.h"
+#include "LevelObjectManager.h"
+
 
 //スタート関数
 bool Mobius::Start()
@@ -20,5 +22,7 @@ Mobius::~Mobius()
 {
 	//モデルレンダラーの破棄
 	DeleteGO(m_modelRender);
+	//マネージャーにメビウスの輪が消去されたと伝える
+	CLevelObjectManager::GetInstance()->SetMobius(nullptr);
 }
 

--- a/GameTemplate/Game/OOReverseALL.cpp
+++ b/GameTemplate/Game/OOReverseALL.cpp
@@ -19,6 +19,9 @@ bool OOReverseALL::StartSub()
 	GetOBB().SetDirectionLength({ 10.0f,400.0f,400.0f });
 	GetOBB().SetPivot({ 0.5f,0.0f,0.5f });
 
+	//オブジェクトと当たらないようにする
+	SetFlagIsHit(false);
+
 	//changeSEのサウンドキューを生成する
 	m_changeSE = NewGO<CSoundCue>(0);
 	//changeSEのサウンドキューを、waveファイルを指定して初期化する。

--- a/GameTemplate/Game/ObstacleObject.cpp
+++ b/GameTemplate/Game/ObstacleObject.cpp
@@ -9,7 +9,7 @@ bool CObstacleObject::PureVirtualStart()
 	COBBWorld::GetInstance()->AddOBB(&GetOBB());
 
 	//モデルの回転を、現在の場所とイイ感じに合わせる
-	CheckWayPoint();
+	//CheckWayPoint();
 
 	CheckFrontOrBackSide(false);
 

--- a/GameTemplate/Game/Player.cpp
+++ b/GameTemplate/Game/Player.cpp
@@ -41,7 +41,7 @@ bool Player::Start()
 	m_onWayPosition = m_position;
 
 	//ステージのメビウスの輪の参照を得る
-	m_mobius = FindGO<Mobius>("Mobius");
+	m_mobius = CLevelObjectManager::GetInstance()->GetMobius();
 
 
 	//初期化処理

--- a/GameTemplate/Game/Player.h
+++ b/GameTemplate/Game/Player.h
@@ -130,6 +130,15 @@ public://publicなメンバ関数
 	}
 
 	/// <summary>
+	/// スタン中か？を得る
+	/// </summary>
+	/// <returns>スタン中か？</returns>
+	const bool GetStunFlag()const
+	{
+		return m_stunFlag;
+	}
+
+	/// <summary>
 	/// プレイヤーがオブジェクトを持っているかどうかを設定する
 	/// 持っている場合はtrueを渡す
 	/// </summary>

--- a/GameTemplate/Game/ROaxe_pickaxe.cpp
+++ b/GameTemplate/Game/ROaxe_pickaxe.cpp
@@ -8,11 +8,7 @@ bool ROaxe_pickaxe::StartSub()
 	Init("Assets/modelData/axe.tkm", enAxe,
 		"Assets/modelData/pickaxe.tkm", enPickaxe);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
+
 
 	return true;
 }

--- a/GameTemplate/Game/RObird_fish.cpp
+++ b/GameTemplate/Game/RObird_fish.cpp
@@ -29,12 +29,6 @@ bool RObird_fish::StartSub()
 		m_otherModelRender[i]->Deactivate();
 	}
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
-
 	return true;
 }
 

--- a/GameTemplate/Game/ROkey_padlock.cpp
+++ b/GameTemplate/Game/ROkey_padlock.cpp
@@ -8,11 +8,7 @@ bool ROkey_padlock::StartSub()
 	Init("Assets/modelData/key.tkm", enKey,
 		"Assets/modelData/padlock.tkm", enPadlock);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
+
 
 	//padlockbreakSEのサウンドキューを生成する
 	m_padlockbreakSE = NewGO<CSoundCue>(0);

--- a/GameTemplate/Game/ROkeymold_empty.cpp
+++ b/GameTemplate/Game/ROkeymold_empty.cpp
@@ -9,11 +9,7 @@ bool ROkeymold_empty::StartSub()
 	Init("Assets/modelData/key_mold.tkm", enKeymold,
 		"Assets/modelData/key_mold.tkm", enKeymold);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
+
 
 	return true;
 }

--- a/GameTemplate/Game/ROleft_right.cpp
+++ b/GameTemplate/Game/ROleft_right.cpp
@@ -8,11 +8,6 @@ bool ROleft_right::StartSub()
 	Init("Assets/modelData/left.tkm", enLeftType,
 		"Assets/modelData/right.tkm", enRightType);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
 
 	return true;
 }

--- a/GameTemplate/Game/ROmizu_kori.cpp
+++ b/GameTemplate/Game/ROmizu_kori.cpp
@@ -8,11 +8,6 @@ bool ROmizu_kori::StartSub()
 	Init("Assets/modelData/water.tkm", enWater,
 		"Assets/modelData/fire.tkm", enFire);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
 
 	return true;
 }

--- a/GameTemplate/Game/ROnail_bar.cpp
+++ b/GameTemplate/Game/ROnail_bar.cpp
@@ -6,13 +6,9 @@ bool ROnail_bar::StartSub()
 {
 	//初期化用関数
 	Init("Assets/modelData/nail.tkm", enNail,
-		"Assets/modelData/bar.tkm", enBar);
+		"Assets/modelData/hammer.tkm", enBar);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
+
 
 	return true;
 }

--- a/GameTemplate/Game/ROrunning_stop.cpp
+++ b/GameTemplate/Game/ROrunning_stop.cpp
@@ -8,11 +8,6 @@ bool ROrunning_stop::StartSub()
 	Init("Assets/modelData/running.tkm", enRunning,
 		"Assets/modelData/stop.tkm", enStop);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
 
 	return true;
 }

--- a/GameTemplate/Game/ROwire_string.cpp
+++ b/GameTemplate/Game/ROwire_string.cpp
@@ -8,12 +8,6 @@ bool ROwire_string::StartSub()
 	Init("Assets/modelData/wire.tkm", enWire,
 		"Assets/modelData/string.tkm", enString);
 
-	//OBBのサイズを設定
-	Vector3 obbSize;
-	obbSize = { 200.0f,200.0f,400.0f };
-	//OBBの方向ベクトルの長さを設定
-	GetOBB().SetDirectionLength(obbSize);
-
 	return true;
 }
 

--- a/GameTemplate/Game/ReversibleObject.h
+++ b/GameTemplate/Game/ReversibleObject.h
@@ -9,9 +9,10 @@
 class CReversibleObject : public ILevelObjectBase
 {
 public:		//自動で呼ばれるメンバ関数
+	CReversibleObject();					//コンストラクタ
 	bool PureVirtualStart()override final;	//スタート関数
 	virtual ~CReversibleObject();			//デストラクタ
-	void PureVirtualUpdate()override final;			//アップデート関数
+	void PureVirtualUpdate()override final;	//アップデート関数
 
 public:
 	/// <summary>

--- a/GameTemplate/Game/StageBase.cpp
+++ b/GameTemplate/Game/StageBase.cpp
@@ -121,7 +121,10 @@ void IStageBase::LoadLevel(const char* tklFilePath)
 	std::size_t vecSize = 0;
 
 	//プレイヤーのポインタ
-	Player* pPlayer;
+	Player* pPlayer = nullptr;
+
+	//ステージのメビウスの輪のポインタ
+	Mobius* mobius = nullptr;
 
 	//スイッチのポインタ
 	OOTransparentSwitch* switchObject = nullptr;
@@ -154,7 +157,6 @@ void IStageBase::LoadLevel(const char* tklFilePath)
 			}
 			else if (objData.EqualObjectName(L"Mobius") == true)
 			{
-				Mobius* mobius;
 				mobius = NewGO<Mobius>(0, "Mobius");
 				mobius->SetPosition(objData.position);
 				mobius->SetRotation(objData.rotation);
@@ -558,6 +560,8 @@ void IStageBase::LoadLevel(const char* tklFilePath)
 		});
 
 
+	//ステージのメビウスの輪をマネージャーに登録
+	CLevelObjectManager::GetInstance()->SetMobius(mobius);
 	//プレイヤーをマネージャーに登録
 	CLevelObjectManager::GetInstance()->SetPlayer(pPlayer);
 	//ロードしたレベルにあったウェイポイントをマネージャーに登録する

--- a/GameTemplate/Game/TransparentSwitch.cpp
+++ b/GameTemplate/Game/TransparentSwitch.cpp
@@ -20,6 +20,10 @@ OOTransparentSwitch::OOTransparentSwitch()
 
 	//点滅時のフォントのカラーを設定
 	m_blinkColor = { 1.0f,0.0f,0.0f,1.0f };
+
+
+	//ウェイポイントからの奥行の距離を設定
+	SetZPosLen(100.0f);
 }
 //スタート関数
 bool OOTransparentSwitch::StartSub()
@@ -55,6 +59,12 @@ bool OOTransparentSwitch::StartSub()
 	m_fadeSR->SetMulColor({ 1.0f,1.0f,1.0f,0.0f });
 	//非表示にする
 	m_fadeSR->Deactivate();
+
+	//OBBのサイズを設定
+	Vector3 obbSize;
+	obbSize = { 100.0f,200.0f,600.0f };
+	//OBBの方向ベクトルの長さを設定
+	GetOBB().SetDirectionLength(obbSize);
 
 	return true;
 }


### PR DESCRIPTION
アイテムの位置を奥側に統一しておいた
その代わり、重なって元の位置に戻ろうとするやつをループさせるとバグるようになった。
キャパシティを分かりやすくするときに直す