### PR TITLE
デバック用に障害オブジェクトを素通りできるようにしたままだったから直した。

### DIFF
--- a/GameTemplate/Game/ObstacleObject.cpp
+++ b/GameTemplate/Game/ObstacleObject.cpp
@@ -6,7 +6,7 @@ bool CObstacleObject::PureVirtualStart()
 {
 	//OBBWorldに自身のOBBを登録する
 	//これによってPlayerが通れなくなる
-	//COBBWorld::GetInstance()->AddOBB(&GetOBB());
+	COBBWorld::GetInstance()->AddOBB(&GetOBB());
 
 	//モデルの回転を、現在の場所とイイ感じに合わせる
 	//CheckWayPoint();


### PR DESCRIPTION
デバック用に障害オブジェクトを素通りできるようにしたままだったから直した。